### PR TITLE
Issue 193: SUBSTRING slice message

### DIFF
--- a/src/sqlancer/duckdb/DuckDBErrors.java
+++ b/src/sqlancer/duckdb/DuckDBErrors.java
@@ -63,7 +63,7 @@ public final class DuckDBErrors {
     }
 
     private static void addFunctionErrors(ExpectedErrors errors) {
-        errors.add("SUBSTRING cannot handle negative offsets");
+        errors.add("SUBSTRING cannot handle negative lengths");
         errors.add("is undefined outside [-1,1]"); // ACOS etc
         errors.add("invalid type specifier"); // PRINTF
         errors.add("argument index out of range"); // PRINTF


### PR DESCRIPTION
Since negative offsets are legal
in DuckDB (and SQLite) but negative
lengths are not, the message has
been updated to reflect reality.